### PR TITLE
Fix code scanning alert no. 6: Incomplete string escaping or encoding

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,7 +76,7 @@ function writeWordJs(data, src) {
             let line = '';
             for (const lang in data[word]) {
                 if (data[word].hasOwnProperty(lang)) {
-                    line += '"' + lang + '": "' + padRight(data[word][lang].replace(/"/g, '\\"').replace(/\\/g, '\\\\') + '",', 50) + ' ';
+                    line += '"' + lang + '": "' + padRight(data[word][lang].replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '",', 50) + ' ';
                 }
             }
             if (line) {


### PR DESCRIPTION
Fixes [https://github.com/zloe/ioBroker.idm-multitalent_002/security/code-scanning/6](https://github.com/zloe/ioBroker.idm-multitalent_002/security/code-scanning/6)

To fix the problem, we need to ensure that backslashes are escaped before any other characters. This can be done by adding a `replace` call to handle backslashes before the existing `replace` calls for double quotes. This ensures that all backslashes are properly escaped, preventing any potential injection attacks or malformed output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
