### PR TITLE
Fix code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,7 +72,7 @@ function writeWordJs(data, src) {
     text += 'systemDictionary = {\n';
     for (const word in data) {
         if (data.hasOwnProperty(word)) {
-            text += '    ' + padRight('"' + word.replace(/"/g, '\\"') + '": {', 50);
+            text += '    ' + padRight('"' + word.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '": {', 50);
             let line = '';
             for (const lang in data[word]) {
                 if (data[word].hasOwnProperty(lang)) {


### PR DESCRIPTION
Fixes [https://github.com/zloe/ioBroker.idm-multitalent_002/security/code-scanning/3](https://github.com/zloe/ioBroker.idm-multitalent_002/security/code-scanning/3)

To fix the problem, we need to ensure that backslashes are properly escaped in addition to double quotes. This can be achieved by adding a `replace` call to handle backslashes before the existing `replace` call for double quotes. This ensures that all backslashes are escaped before any other characters are processed.

- Modify the `replace` method on line 75 to include escaping for backslashes.
- Ensure that the escaping is done in the correct order: first escape backslashes, then escape double quotes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
