### PR TITLE
Fix code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ function lang2data(lang) {
     for (const w in lang) {
         if (lang.hasOwnProperty(w)) {
             count++;
-            const key = '    "' + w.replace(/"/g, '\\"') + '": ';
+            const key = '    "' + w.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '": ';
             str += key + '"' + lang[w].replace(/"/g, '\\"') + '",\n';
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/zloe/ioBroker.idm-multitalent_002/security/code-scanning/1](https://github.com/zloe/ioBroker.idm-multitalent_002/security/code-scanning/1)

To fix the problem, we need to ensure that backslashes are also escaped in the input string `w`. This can be achieved by first replacing backslashes with double backslashes and then replacing double quotes with escaped double quotes. This ensures that all occurrences of backslashes and double quotes are properly escaped.

The best way to fix this without changing existing functionality is to modify the `w.replace` call on line 34 to handle backslashes. We will use a regular expression with the `g` flag to replace all occurrences of backslashes and double quotes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
