### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ function lang2data(lang) {
         if (lang.hasOwnProperty(w)) {
             count++;
             const key = '    "' + w.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '": ';
-            str += key + '"' + lang[w].replace(/"/g, '\\"') + '",\n';
+            str += key + '"' + lang[w].replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '",\n';
         }
     }
     if (!count) {


### PR DESCRIPTION
Fixes [https://github.com/zloe/ioBroker.idm-multitalent_002/security/code-scanning/2](https://github.com/zloe/ioBroker.idm-multitalent_002/security/code-scanning/2)

To fix the problem, we need to ensure that backslashes in the `lang[w]` values are properly escaped. This can be done by adding a `replace` method call to escape backslashes before escaping double quotes. This ensures that all occurrences of backslashes are handled correctly.

- We will modify line 35 to include a `replace` method call for backslashes.
- The change will be made in the `lang2data` function within the `gulpfile.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
